### PR TITLE
Make this work vs. Terraform v0.12.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Example solution for :egg: vs :chicken: problem - how to create infrastructure f
 
 ## Assumptions
 
-* [Terraform](https://www.terraform.io/) installed (approach tested against `v0.12.9`)
+* [Terraform](https://www.terraform.io/) installed (approach tested against `v0.12.24`)
 * [AWS S3 backend](https://www.terraform.io/docs/backends/types/s3.html) with DynamoDB table for locking will be used
 * operator should have [AWS credentials in profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) - for the purpose of this repo we use `terraform` profile
 * backend will be created and maintained under `base` workspace

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -75,6 +75,7 @@ resource "aws_s3_bucket_policy" "terraform_state" {
 
   bucket = aws_s3_bucket.terraform_state.id
   policy = data.template_file.terraform_state_policy.rendered
+  count = "${length(var.operators) > 0 ? 1 : 0 }"
 }
 
 # DynamoDB

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -5,7 +5,7 @@ variable "bootstrap" {
 }
 
 variable "operators" {
-  type = "list"
+  type = list
 }
 
 variable "bucket" {}

--- a/setup/main.tf
+++ b/setup/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  profile = "${var.profile}"
-  region  = "${var.region}"
+  profile = var.profile
+  region  = var.region
 }
 
 module "backend" {
@@ -8,7 +8,7 @@ module "backend" {
 
   bootstrap      = "${terraform.workspace == "base" ? 1 : 0}"
   operators      = "${local.operators}"
-  bucket         = "${var.bucket}"
-  dynamodb_table = "${var.dynamodb_table}"
-  key            = "${var.key}"
+  bucket         = var.bucket
+  dynamodb_table = var.dynamodb_table
+  key            = var.key
 }

--- a/setup/variables.tf
+++ b/setup/variables.tf
@@ -1,7 +1,6 @@
 locals {
   operators = [
-    "john.blacksmith",
-    "kate.snow"
+    # Put any local operator IAM user names here
   ]
 }
 


### PR DESCRIPTION
This also removes all the deprecation warnings related to
warn that Terraform 0.11-style quoted string interpolation.

It removes the default list of operators from the S3 bucket too - those are optional.